### PR TITLE
Allow install parameter to be custom

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,9 +6,10 @@
 # Copyright 2014 Rafael Cristaldo
 
 class	libreoffice::install (
-	$libreoffice = $libreoffice::params::libreoffice) inherits libreoffice {
+	$libreoffice = $libreoffice::params::libreoffice,
+	$install = $libreoffice::params::install) inherits libreoffice {
 
 	package { $libreoffice:
-		ensure => latest,
+		ensure => $install,
 		}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,8 @@ class	libreoffice::params {
 	 default: {
 	 $lib_lang = $def_lang }
          } 
+# Default install parameter
+$install = 'latest'
 
 # Some releases hasn't the official repositories updated yet!
 # Because of this, we needed to change some release's repositories, unless ppa.


### PR DESCRIPTION
This will allow for "installed, latest, present, or specific version lock" of libreoffice packages.
This will also help from auto upgrading libreoffice with default "latest" for packages.
